### PR TITLE
Noop on renderFile if file contents is not utf8

### DIFF
--- a/lib/render-file.js
+++ b/lib/render-file.js
@@ -6,6 +6,7 @@
 
 const extend = require('extend');
 const path = require('path');
+const utf8 = require('is-utf8');
 
 /**
  * Local
@@ -22,6 +23,7 @@ module.exports = function renderFile(files, filename, metadata, source, options)
   const parts = filename.split('.');
   const name = parts.shift();
   const file = files[filename];
+  if (!utf8(file.contents)) return filename;
 
   // Set filename in options, necessary for some languages
   options.filename = path.join(source, filename);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "extend": "^3.0.0",
     "inputformat-to-jstransformer": "^1.1.8",
+    "is-utf8": "^0.2.1",
     "jstransformer": "^1.0.0"
   }
 }

--- a/test/render-file.spec.js
+++ b/test/render-file.spec.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const renderFile = require('../lib/render-file');
+
+describe('render-file', () => {
+  it('does not corrupt binary data', () => {
+    const binaryBuffer = new Buffer('042697a30b2dafbdf91bf66bdacdcba8', 'hex');
+
+    const files = { foo: { contents: binaryBuffer } };
+    const metadata = {};
+    const source = '/src';
+    const options = {};
+
+    renderFile(files, 'foo', metadata, source, options);
+    assert(files.foo.contents === binaryBuffer,
+      'Buffer must be the same after untransformed processing');
+  });
+});
+


### PR DESCRIPTION
This is to prevent binary files from being corrupted. A binary file's contents cannot be read and then cast back to a buffer.